### PR TITLE
support custom Hive/Impala JDBC drivers through CLI parameters

### DIFF
--- a/src/main/java/liquibase/ext/metastore/configuration/HiveMetastoreConfiguration.java
+++ b/src/main/java/liquibase/ext/metastore/configuration/HiveMetastoreConfiguration.java
@@ -5,6 +5,8 @@ import liquibase.configuration.AbstractConfigurationContainer;
 public class HiveMetastoreConfiguration extends AbstractConfigurationContainer {
     private static final String LOCK = "lock";
     private static final String SYNC_DDL = "syncDDL";
+    private static final String CUSTOM_HIVE_JDBC_DRIVER = "customHiveJDBCDriver";
+    private static final String CUSTOM_IMPALA_JDBC_DRIVER = "customImpalaJDBCDriver";
 
     public HiveMetastoreConfiguration() {
         super("liquibase");
@@ -16,6 +18,14 @@ public class HiveMetastoreConfiguration extends AbstractConfigurationContainer {
                 .setDescription("Wrap every statement with SYNC_DDL")
                 .setDefaultValue(true)
                 .addAlias("syncDDL");
+        getContainer().addProperty(CUSTOM_HIVE_JDBC_DRIVER, String.class)
+                .setDescription("Set custom JDBC driver for Hive")
+                .setDefaultValue("com.cloudera.hive.jdbc41.HS2Driver")
+                .addAlias("customHiveJDBCDriver");
+        getContainer().addProperty(CUSTOM_IMPALA_JDBC_DRIVER, String.class)
+                .setDescription("Set custom JDBC driver for Impala")
+                .setDefaultValue("com.cloudera.impala.jdbc41.Driver")
+                .addAlias("customImpalaJDBCDriver");
     }
 
     public boolean getLock() {
@@ -33,6 +43,24 @@ public class HiveMetastoreConfiguration extends AbstractConfigurationContainer {
 
     public HiveMetastoreConfiguration setSyncDDL(boolean syncDdl) {
         getContainer().setValue(SYNC_DDL, Boolean.class);
+        return this;
+    }
+
+    public String getHiveDriver() {
+        return getContainer().getValue(CUSTOM_HIVE_JDBC_DRIVER, String.class);
+    }
+
+    public HiveMetastoreConfiguration setHiveDriver(String driverName) {
+        getContainer().setValue(CUSTOM_HIVE_JDBC_DRIVER, String.class);
+        return this;
+    }
+
+    public String getImpalaDriver() {
+        return getContainer().getValue(CUSTOM_IMPALA_JDBC_DRIVER, String.class);
+    }
+
+    public HiveMetastoreConfiguration setImpalaDriver(String driverName) {
+        getContainer().setValue(CUSTOM_IMPALA_JDBC_DRIVER, String.class);
         return this;
     }
 }

--- a/src/main/java/liquibase/ext/metastore/hive/database/HiveDatabase.java
+++ b/src/main/java/liquibase/ext/metastore/hive/database/HiveDatabase.java
@@ -1,5 +1,7 @@
 package liquibase.ext.metastore.hive.database;
 
+import liquibase.configuration.LiquibaseConfiguration;
+import liquibase.ext.metastore.configuration.HiveMetastoreConfiguration;
 import liquibase.ext.metastore.database.HiveMetastoreDatabase;
 
 import java.util.Arrays;
@@ -7,7 +9,9 @@ import java.util.Arrays;
 public class HiveDatabase extends HiveMetastoreDatabase {
 
     public HiveDatabase() {
-        super("Apache Hive", "jdbc:hive2", "com.cloudera.hive.jdbc41.HS2Driver");
+        super("Apache Hive",
+                "jdbc:hive2",
+                LiquibaseConfiguration.getInstance().getConfiguration(HiveMetastoreConfiguration.class).getHiveDriver());
     }
 
     @Override

--- a/src/main/java/liquibase/ext/metastore/impala/database/ImpalaDatabase.java
+++ b/src/main/java/liquibase/ext/metastore/impala/database/ImpalaDatabase.java
@@ -16,7 +16,9 @@ public class ImpalaDatabase extends HiveMetastoreDatabase {
     private static Boolean syncDdl = LiquibaseConfiguration.getInstance().getConfiguration(HiveMetastoreConfiguration.class).getSyncDDL();
 
     public ImpalaDatabase() {
-        super("Impala", "jdbc:impala", "com.cloudera.impala.jdbc41.Driver");
+        super("Impala",
+                "jdbc:impala",
+                LiquibaseConfiguration.getInstance().getConfiguration(HiveMetastoreConfiguration.class).getImpalaDriver());
     }
 
     @Override


### PR DESCRIPTION
This changes should support custom JDBC driver implementation through the command line arguments, addressed issue #5  . Test this changes with my local pseudo-distributed CDH cluster.